### PR TITLE
Fix: Correct SearchIndexModel instantiation for vector search

### DIFF
--- a/seeds/seed_database.py
+++ b/seeds/seed_database.py
@@ -30,26 +30,26 @@ async def create_search_index():
             await db.create_collection("products")
 
         collection = Database.get_collection("products")
-        await collection.drop_indexes()
+        try:
+            print("Dropping existing search index...")
+            await collection.drop_search_index("vector_index")
+        except Exception as e:
+            print(f"Could not drop index 'vector_index' (it may not exist): {e}")
 
-        search_index_definition = {
-            "name": "vector_index",
-            "type": "vectorSearch",
-            "definition": {
-                "mappings": {
-                    "dynamic": True,
-                    "fields": [
-                        {
-                            "type": "vector",
-                            "path": "embedding",
-                            "numDimensions": 768,
-                            "similarity": "cosine",
-                        }
-                    ],
-                }
+        search_index_model = SearchIndexModel(
+            name="vector_index",
+            type="vectorSearch",
+            definition={
+                "fields": [
+                    {
+                        "type": "vector",
+                        "path": "embedding",
+                        "numDimensions": 768,
+                        "similarity": "cosine",
+                    }
+                ]
             },
-        }
-        search_index_model = SearchIndexModel(search_index_definition)
+        )
         print("Creating search index...")
         await collection.create_search_indexes([search_index_model])
     except Exception as e:


### PR DESCRIPTION
The `SearchIndexModel` was being instantiated with an incorrect structure for a vector search index, causing an 'Attribute mappings missing' error. This was because the `definition` was nested incorrectly and the index was not being explicitly dropped before creation.

This commit fixes the issue by:
- Restructuring the `SearchIndexModel` to the correct format for `vectorSearch`.
- Using `drop_search_index()` to explicitly remove the old index before creating a new one.